### PR TITLE
Add HTTP methods support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,10 +12,10 @@ let package = Package(
     .tvOS(.v13),
   ],
   products: [
-    .library(name: "Functions", targets: ["Functions"]),
+    .library(name: "Functions", targets: ["Functions"])
   ],
   dependencies: [
-    .package(url: "https://github.com/kean/Get", from: "2.1.5"),
+    .package(url: "https://github.com/kean/Get", from: "2.1.5")
   ],
   targets: [
     .target(

--- a/Sources/Functions/FunctionsClient.swift
+++ b/Sources/Functions/FunctionsClient.swift
@@ -76,7 +76,7 @@ public final class FunctionsClient {
   ) async throws -> (Data, HTTPURLResponse) {
     let request = Request(
       path: functionName,
-      method: .post,
+      method: invokeOptions.method.map({ HTTPMethod(rawValue: $0.rawValue) }) ?? .post,
       body: invokeOptions.body,
       headers: invokeOptions.headers.merging(headers) { first, _ in first }
     )
@@ -87,7 +87,7 @@ public final class FunctionsClient {
       throw URLError(.badServerResponse)
     }
 
-    guard 200 ..< 300 ~= httpResponse.statusCode else {
+    guard 200..<300 ~= httpResponse.statusCode else {
       throw FunctionsError.httpError(code: httpResponse.statusCode, data: response.data)
     }
 

--- a/Sources/Functions/Types.swift
+++ b/Sources/Functions/Types.swift
@@ -13,10 +13,11 @@ public enum FunctionsError: Error, LocalizedError {
 }
 
 public struct FunctionInvokeOptions {
+  let method: Method?
   let headers: [String: String]
   let body: Data?
 
-  public init(headers: [String: String] = [:], body: some Encodable) {
+  public init(method: Method? = nil, headers: [String: String] = [:], body: some Encodable) {
     var headers = headers
 
     switch body {
@@ -32,11 +33,21 @@ public struct FunctionInvokeOptions {
       self.body = try? JSONEncoder().encode(body)
     }
 
+    self.method = method
     self.headers = headers
   }
 
-  public init(headers: [String: String] = [:]) {
+  public init(method: Method? = nil, headers: [String: String] = [:]) {
+    self.method = method
     self.headers = headers
     body = nil
+  }
+
+  public enum Method: String {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case patch = "PATCH"
+    case delete = "DELETE"
   }
 }

--- a/Tests/FunctionsTests/FunctionInvokeOptionsTests.swift
+++ b/Tests/FunctionsTests/FunctionInvokeOptionsTests.swift
@@ -1,5 +1,6 @@
-@testable import Functions
 import XCTest
+
+@testable import Functions
 
 final class FunctionInvokeOptionsTests: XCTestCase {
   func testStringBody() {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Close https://github.com/supabase-community/supabase-swift/issues/104

## What is the new behavior?

Add support for defining the HTTP method to use when calling the function.
