### PR TITLE
add query to arguments

### DIFF
--- a/Sources/Functions/FunctionsClient.swift
+++ b/Sources/Functions/FunctionsClient.swift
@@ -31,11 +31,13 @@ public final class FunctionsClient {
   ///   - functionName: the name of the function to invoke.
   public func invoke<Response>(
     functionName: String,
+    query: [(String, String?)]?,
     invokeOptions: FunctionInvokeOptions = .init(),
     decode: (Data, HTTPURLResponse) throws -> Response
   ) async throws -> Response {
     let (data, response) = try await rawInvoke(
       functionName: functionName,
+      query: query,
       invokeOptions: invokeOptions
     )
     return try decode(data, response)
@@ -46,11 +48,13 @@ public final class FunctionsClient {
   ///   - functionName: the name of the function to invoke.
   public func invoke<T: Decodable>(
     functionName: String,
+    query: [(String, String?)]?,
     invokeOptions: FunctionInvokeOptions = .init(),
     decoder: JSONDecoder = JSONDecoder()
   ) async throws -> T {
     try await invoke(
       functionName: functionName,
+      query: query,
       invokeOptions: invokeOptions,
       decode: { data, _ in try decoder.decode(T.self, from: data) }
     )
@@ -61,10 +65,12 @@ public final class FunctionsClient {
   ///   - functionName: the name of the function to invoke.
   public func invoke(
     functionName: String,
+    query: [(String, String?)]?,
     invokeOptions: FunctionInvokeOptions = .init()
   ) async throws {
     try await invoke(
       functionName: functionName,
+      query: query,
       invokeOptions: invokeOptions,
       decode: { _, _ in () }
     )
@@ -72,11 +78,13 @@ public final class FunctionsClient {
 
   private func rawInvoke(
     functionName: String,
+    query: [(String, String?)]?,
     invokeOptions: FunctionInvokeOptions
   ) async throws -> (Data, HTTPURLResponse) {
     let request = Request(
       path: functionName,
       method: invokeOptions.method.map({ HTTPMethod(rawValue: $0.rawValue) }) ?? .post,
+      query: query,
       body: invokeOptions.body,
       headers: invokeOptions.headers.merging(headers) { first, _ in first }
     )

--- a/Sources/Functions/FunctionsClient.swift
+++ b/Sources/Functions/FunctionsClient.swift
@@ -31,7 +31,7 @@ public final class FunctionsClient {
   ///   - functionName: the name of the function to invoke.
   public func invoke<Response>(
     functionName: String,
-    query: [(String, String?)]?,
+    query: [(String, String?)]? = nil,
     invokeOptions: FunctionInvokeOptions = .init(),
     decode: (Data, HTTPURLResponse) throws -> Response
   ) async throws -> Response {
@@ -48,7 +48,7 @@ public final class FunctionsClient {
   ///   - functionName: the name of the function to invoke.
   public func invoke<T: Decodable>(
     functionName: String,
-    query: [(String, String?)]?,
+    query: [(String, String?)]? = nil,
     invokeOptions: FunctionInvokeOptions = .init(),
     decoder: JSONDecoder = JSONDecoder()
   ) async throws -> T {
@@ -65,7 +65,7 @@ public final class FunctionsClient {
   ///   - functionName: the name of the function to invoke.
   public func invoke(
     functionName: String,
-    query: [(String, String?)]?,
+    query: [(String, String?)]? = nil,
     invokeOptions: FunctionInvokeOptions = .init()
   ) async throws {
     try await invoke(
@@ -78,7 +78,7 @@ public final class FunctionsClient {
 
   private func rawInvoke(
     functionName: String,
-    query: [(String, String?)]?,
+    query: [(String, String?)]? = nil,
     invokeOptions: FunctionInvokeOptions
   ) async throws -> (Data, HTTPURLResponse) {
     let request = Request(


### PR DESCRIPTION
## What kind of change does this PR introduce?
    you can add query params when you want to invoke functions
Bug fix, feature, docs update, ...
   feature
## What is the current behavior?
   you can't add any query params to your functions
Please link any relevant issues here.
  /habit-functions?date=2023-09-08
## What is the new behavior?
 you can append query params to your function name and can parse it on typescript side. 
 i wanted to add some filter  mechanism to my edge functions but i don't want to send my data with post request.
 with this PR you can add query as much as you want and parse in your backend(deno-ts) and return clean model
Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
