### PR TITLE
fix: do not override Content-Type header

### DIFF
--- a/Sources/Functions/Types.swift
+++ b/Sources/Functions/Types.swift
@@ -18,23 +18,23 @@ public struct FunctionInvokeOptions {
   let body: Data?
 
   public init(method: Method? = nil, headers: [String: String] = [:], body: some Encodable) {
-    var headers = headers
+    var defaultHeaders = [String: String]()
 
     switch body {
     case let string as String:
-      headers["Content-Type"] = "text/plain"
+      defaultHeaders["Content-Type"] = "text/plain"
       self.body = string.data(using: .utf8)
     case let data as Data:
-      headers["Content-Type"] = "application/octet-stream"
+      defaultHeaders["Content-Type"] = "application/octet-stream"
       self.body = data
     default:
       // default, assume this is JSON
-      headers["Content-Type"] = "application/json"
+      defaultHeaders["Content-Type"] = "application/json"
       self.body = try? JSONEncoder().encode(body)
     }
 
     self.method = method
-    self.headers = headers
+    self.headers = defaultHeaders.merging(headers) { _, new in new }
   }
 
   public init(method: Method? = nil, headers: [String: String] = [:]) {

--- a/Tests/FunctionsTests/FunctionInvokeOptionsTests.swift
+++ b/Tests/FunctionsTests/FunctionInvokeOptionsTests.swift
@@ -23,4 +23,15 @@ final class FunctionInvokeOptionsTests: XCTestCase {
     XCTAssertEqual(options.headers["Content-Type"], "application/json")
     XCTAssertNotNil(options.body)
   }
+
+  func testMultipartFormDataBody() {
+    let boundary = "Boundary-\(UUID().uuidString)"
+    let contentType = "multipart/form-data; boundary=\(boundary)"
+    let options = FunctionInvokeOptions(
+      headers: ["Content-Type": contentType],
+      body: "binary value".data(using: .utf8)!
+    )
+    XCTAssertEqual(options.headers["Content-Type"], contentType)
+    XCTAssertNotNil(options.body)
+  }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Closes #4 

## What is the current behavior?

`FunctionInvokeOptions` overrides the specified `Content-Type` header value to `application/octet-stream` when `body` is of type `Data`.

## What is the new behavior?

Functions are invoked with the specified `Content-Type` header value.

## Additional context

Fix verified by:
1. Running the added test case.
2. Invoking a function that handles multipart/form-data requests.